### PR TITLE
fix syntax highlight theme and basic stylesheet files missing

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -39,9 +39,6 @@ add_function_parentheses = True
 # unit titles (such as .. function::).
 add_module_names = True
 
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
-
 # -- Options for HTML output --------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with

--- a/ustackdocstheme/theme/ustackdocs/css.html
+++ b/ustackdocstheme/theme/ustackdocs/css.html
@@ -2,7 +2,7 @@
 <link href="{{pathto('_static/css/bootstrap.min.css', 1)}}" rel="stylesheet">
 
 <!-- Pygments CSS -->
-<link href="{{pathto('_static/css/native.css', 1)}}" rel="stylesheet">
+<link href="{{pathto('_static/pygments.css', 1)}}" rel="stylesheet">
 
 <!-- Fonts -->
 <link href="{{pathto('_static/css/font-awesome.min.css', 1)}}" rel="stylesheet">

--- a/ustackdocstheme/theme/ustackdocs/theme.conf
+++ b/ustackdocstheme/theme/ustackdocs/theme.conf
@@ -1,6 +1,6 @@
 [theme]
 inherit = openstackdocs
-stylesheet = css/basic.css
+stylesheet = basic.css
 pygments_style = native
 
 [options]


### PR DESCRIPTION
* fix syntax highlight stylesheet file missing
* fix basic stylesheet file missing
* remove `pygments_style` option from demo documentation configuration